### PR TITLE
chore(app): make mainnet default network

### DIFF
--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -19,7 +19,7 @@ export const CONFIG = {
 	MIN_THRESHOLD: 1,
 
 	// Network
-	DEFAULT_NETWORK: 'testnet' as const,
+	DEFAULT_NETWORK: 'mainnet' as const,
 
 	// Pagination
 	DEFAULT_PAGE_SIZE: 20,


### PR DESCRIPTION
usually the network is also stored in localstorage as `iotaNetwork`. If you have that one, delete it, otherwise this will remain as testnet

Fixes #37 